### PR TITLE
Fix traditional ssh RSA support and add useful README

### DIFF
--- a/amzn1/SPECS/openssh.spec
+++ b/amzn1/SPECS/openssh.spec
@@ -314,6 +314,13 @@ UseDNS no
 UsePAM yes
 KexAlgorithms -diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
 EOF
+# Modify ssh config file, to ensure that traditional RSA-type key authentication is available to avoid git clone failures.
+# See: https://support.genymotion.com/hc/en-us/articles/9500420360093-I-get-the-error-no-matching-host-key-type-found-Their-offer-ssh-rsa-when-trying-to-connect-with-SSH
+cat << EOF >> $RPM_BUILD_ROOT/etc/ssh/ssh_config
+Host *
+    HostKeyAlgorithms = +ssh-rsa
+    PubkeyAcceptedAlgorithms = +ssh-rsa
+EOF
 
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install -m644 contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/

--- a/amzn2/SPECS/openssh.spec
+++ b/amzn2/SPECS/openssh.spec
@@ -314,6 +314,13 @@ UseDNS no
 UsePAM yes
 KexAlgorithms -diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
 EOF
+# Modify ssh config file, to ensure that traditional RSA-type key authentication is available to avoid git clone failures.
+# See: https://support.genymotion.com/hc/en-us/articles/9500420360093-I-get-the-error-no-matching-host-key-type-found-Their-offer-ssh-rsa-when-trying-to-connect-with-SSH
+cat << EOF >> $RPM_BUILD_ROOT/etc/ssh/ssh_config
+Host *
+    HostKeyAlgorithms = +ssh-rsa
+    PubkeyAcceptedAlgorithms = +ssh-rsa
+EOF
 
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install -m644 contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/

--- a/amzn2023/SPECS/openssh.spec
+++ b/amzn2023/SPECS/openssh.spec
@@ -314,6 +314,13 @@ UseDNS no
 UsePAM yes
 KexAlgorithms -diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
 EOF
+# Modify ssh config file, to ensure that traditional RSA-type key authentication is available to avoid git clone failures.
+# See: https://support.genymotion.com/hc/en-us/articles/9500420360093-I-get-the-error-no-matching-host-key-type-found-Their-offer-ssh-rsa-when-trying-to-connect-with-SSH
+cat << EOF >> $RPM_BUILD_ROOT/etc/ssh/ssh_config
+Host *
+    HostKeyAlgorithms = +ssh-rsa
+    PubkeyAcceptedAlgorithms = +ssh-rsa
+EOF
 
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install -m644 contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/

--- a/docker.README.md
+++ b/docker.README.md
@@ -1,5 +1,129 @@
 ## Wanna 🐳Docker?
 
+### TLDR
+
+#### I JUST WANT RPMS
+
+This script below can compile rpm packages for all systems.
+
+```bash
+# Download all src files
+source version.env
+PERLMIR=https://www.cpan.org/src/5.0
+if [[ ! -f downloads/$PERLSRC ]]; then
+	curl -k -o downloads/$PERLSRC $PERLMIR/$PERLSRC
+fi
+bash ./pullsrc.sh
+# Define whether to enable Tsinghua University mirror source. (Very useful for Chinese users)
+CHINA_MIRROR=1  # Setting this variable to non-zero means enabling
+OUTPUT="/tmp"
+
+# Specify build CentOS versions
+VERSIONS=("7" "6" "5")
+
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Building CentOS: ${VERSION}"
+  # Build docker image
+  docker build \
+         -t rpm-builder-centos:$VERSION \
+         --build-arg VERSION_NUM=$VERSION \
+         --build-arg CHINA_MIRROR=$CHINA_MIRROR \
+         -f docker/Dockerfile.centos .
+  mkdir -p $OUTPUT/centos/$VERSION
+  # Start container
+  docker run -it --rm \
+         -v $OUTPUT/centos/$VERSION:/data/el$VERSION/RPMS/$(uname -m) \
+         rpm-builder-centos:$VERSION
+done
+
+# Specify build CentOS Stream versions
+VERSIONS=("9" "8")
+
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Building CentOS Stream: ${VERSION}"
+  # Build docker image
+  docker build \
+         -t rpm-builder-centos-stream:$VERSION \
+         --build-arg VERSION_NUM=$VERSION \
+         --build-arg CHINA_MIRROR=$CHINA_MIRROR \
+         -f docker/Dockerfile.centos-stream .
+  mkdir -p $OUTPUT/centos-stream/$VERSION
+  # Start container
+  docker run -it --rm \
+         -v $OUTPUT/centos-stream/$VERSION:/data/el7/RPMS/$(uname -m) \
+         rpm-builder-centos-stream:$VERSION
+done
+
+# Specify build Amazon Linux versions
+VERSIONS=("2023" "2" "1")
+
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Building version: ${VERSION}"
+  # Build docker image
+  docker build \
+         -t rpm-builder-amazonlinux:$VERSION \
+         --build-arg VERSION_NUM=$VERSION \
+         --build-arg CHINA_MIRROR=$CHINA_MIRROR \
+         -f docker/Dockerfile.amazonlinux .
+  mkdir -p $OUTPUT/amazonlinux/$VERSION
+  # Start container
+  docker run -it --rm \
+         -v $OUTPUT/amazonlinux/$VERSION:/data/amzn$VERSION/RPMS/$(uname -m) \
+         rpm-builder-amazonlinux:$VERSION
+done
+
+```
+
+#### I WANT UPLOAD TO NEXUS REPOSITORY
+
+```bash
+# Define output dir
+OUTPUT='/tmp'
+# Define upload auth info
+export NEXUS_REPOSITORY_URL='https://nexus.example.com/service/rest/v1/components?repository=my-yum-hosted'
+export NEXUS_USERNAME='uploader'
+export NEXUS_PASSWORD='Pa$$w0rD'
+
+declare -A MAPPING
+MAPPING["centos"]="7 6 5"
+MAPPING["centos-stream"]="9 8"
+MAPPING["amazonlinux"]="2023 2 1"
+
+function upload_file(){
+  echo "Uploading: $1"
+  echo "Destination: $2"
+  curl \
+    --user "$NEXUS_USERNAME:$NEXUS_PASSWORD" \
+    $NEXUS_REPOSITORY_URL \
+    -H 'accept: application/json' \
+    -H 'Content-Type: multipart/form-data' \
+    -F "yum.directory=$2" \
+    -F "yum.asset=@$1;type=application/x-rpm" \
+    -F "yum.asset.filename=$(basename $1)"
+}
+export -f upload_file
+
+for OS_TYPE in "${!MAPPING[@]}"; do
+    VERSIONS=${MAPPING[$OS_TYPE]}
+    VERSIONS_ARRAY=($VERSIONS)
+
+    # If you need a clearer structure, uncomment the following
+    __OS_TYPE=$OS_TYPE
+    if [ "$OS_TYPE" = 'centos-stream' ];then __OS_TYPE='centos';fi
+    
+    for VERSION in "${VERSIONS_ARRAY[@]}"; do
+        echo "$OS_TYPE $VERSION"
+        find $OUTPUT/$OS_TYPE/$VERSION \
+          -type f \
+          -name '*.rpm' \
+          -exec bash -c 'upload_file "$1" "$2"' _ {} "$__OS_TYPE/$VERSION/$(uname -m)" \;
+    done
+done
+```
+
 ### Create image
 
 #### Login registry
@@ -189,5 +313,125 @@ do
   docker run -it --rm \
          -v $OUT_PATH:/data/$IMAGE_TAG/RPMS \
          $COMPONENT:$IMAGE_TAG
+done
+```
+
+## For ARM users
+
+- *CentOS 6 and lower operating systems **DO NOT** have an image of the ARM architecture.*
+
+- *Amazon Linux 1 **DO NOT** have an image of the ARM architecture.*
+
+#### I JUST WANT RPMS
+
+This script below can compile rpm packages for all support systems.
+
+```bash
+# Download all src files
+bash ./pullsrc.sh
+# Define whether to enable Tsinghua University mirror source. (Very useful for Chinese users)
+CHINA_MIRROR=1  # Setting this variable to non-zero means enabling
+OUTPUT="/tmp"
+
+# Specify build CentOS versions
+VERSION="7"
+
+echo "Building CentOS: ${VERSION}"
+# Build docker image
+docker build \
+       -t rpm-builder-centos:$VERSION \
+       --build-arg VERSION_NUM=$VERSION \
+       --build-arg CHINA_MIRROR=$CHINA_MIRROR \
+       -f docker/Dockerfile.centos .
+mkdir -p $OUTPUT/centos/$VERSION
+# Start container
+docker run -it --rm \
+       -v $OUTPUT/centos/$VERSION:/data/el7/RPMS/$(uname -m) \
+       rpm-builder-centos:$VERSION
+
+# Specify build CentOS Stream versions
+VERSIONS=("9" "8")
+
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Building CentOS Stream: ${VERSION}"
+  # Build docker image
+  docker build \
+         -t rpm-builder-centos-stream:$VERSION \
+         --build-arg VERSION_NUM=$VERSION \
+         --build-arg CHINA_MIRROR=$CHINA_MIRROR \
+         -f docker/Dockerfile.centos-stream .
+  mkdir -p $OUTPUT/centos-stream/$VERSION
+  # Start container
+  docker run -it --rm \
+         -v $OUTPUT/centos-stream/$VERSION:/data/el7/RPMS/$(uname -m) \
+         rpm-builder-centos-stream:$VERSION
+done
+
+# Specify build Amazon Linux versions
+VERSIONS=("2023" "2")
+
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Building version: ${VERSION}"
+  # Build docker image
+  docker build \
+         -t rpm-builder-amazonlinux:$VERSION \
+         --build-arg VERSION_NUM=$VERSION \
+         --build-arg CHINA_MIRROR=$CHINA_MIRROR \
+         -f docker/Dockerfile.amazonlinux .
+  mkdir -p $OUTPUT/amazonlinux/$VERSION
+  # Start container
+  docker run -it --rm \
+         -v $OUTPUT/amazonlinux/$VERSION:/data/amzn$VERSION/RPMS/$(uname -m) \
+         rpm-builder-amazonlinux:$VERSION
+done
+
+```
+
+#### I WANT UPLOAD TO NEXUS REPOSITORY
+
+```bash
+# Define output dir
+OUTPUT='/tmp'
+# Define upload auth info
+export NEXUS_REPOSITORY_URL='https://nexus.example.com/service/rest/v1/components?repository=my-yum-hosted'
+export NEXUS_USERNAME='uploader'
+export NEXUS_PASSWORD='Pa$$w0rD'
+
+declare -A MAPPING
+MAPPING["centos"]="7"
+MAPPING["centos-stream"]="9 8"
+MAPPING["amazonlinux"]="2023 2 1"
+
+function upload_file(){
+  echo "Uploading: $1"
+  echo "Destination: $2"
+  curl \
+    --user "$NEXUS_USERNAME:$NEXUS_PASSWORD" \
+    $NEXUS_REPOSITORY_URL \
+    -H 'accept: application/json' \
+    -H 'Content-Type: multipart/form-data' \
+    -F "yum.directory=$2" \
+    -F "yum.asset=@$1;type=application/x-rpm" \
+    -F "yum.asset.filename=$(basename $1)"
+}
+export -f upload_file
+
+for OS_TYPE in "${!MAPPING[@]}"; do
+    VERSIONS=${MAPPING[$OS_TYPE]}
+    VERSIONS_ARRAY=($VERSIONS)
+
+    # If you need a clearer structure, uncomment the following
+    __OS_TYPE=$OS_TYPE
+    if [ "$OS_TYPE" = 'centos-stream' ];then __OS_TYPE='centos';fi
+    
+    for VERSION in "${VERSIONS_ARRAY[@]}"; do
+        echo "$OS_TYPE $VERSION"
+        find $OUTPUT/$OS_TYPE/$VERSION \
+          -type f \
+          -name '*.rpm' \
+          -exec bash -c 'upload_file "$1" "$2"' _ {} "$__OS_TYPE/$VERSION/$(uname -m)" \;
+    done
 done
 ```

--- a/docker/Dockerfile.centos-stream
+++ b/docker/Dockerfile.centos-stream
@@ -1,6 +1,7 @@
 # Official: https://quay.io/repository/centos/centos?tab=tags
 ARG VERSION_NUM="9"
 FROM quay.io/centos/centos:stream$VERSION_NUM
+ARG VERSION_NUM
 ARG CHINA_MIRROR=0
 LABEL Author="Rex Zhou <zrx879582094@gmail.com>"
 
@@ -10,8 +11,16 @@ WORKDIR /data
 COPY . /data
 
 RUN if [ "$CHINA_MIRROR" != "0" ]; then \
-        yum install -y perl && \
-        perl /data/docker/modify_dnf_source.pl /etc/yum.repos.d/*.repo; \
+        if [ "$VERSION_NUM" = "9" ]; then \
+            yum install -y perl && \
+            perl /data/docker/modify_dnf_source.pl /etc/yum.repos.d/*.repo; \
+        elif [ "$VERSION_NUM" = "8" ]; then \
+            sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+                -e 's|^#baseurl=http://mirror.centos.org/$contentdir|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-vault|g' \
+                -i.bak \
+                /etc/yum.repos.d/CentOS-*.repo && \
+            yum install -y perl; \
+        fi \
     fi && \
     yum clean all && yum makecache && \
     yum groupinstall -y "Development Tools" && \

--- a/docker/modify_yum_source.sh
+++ b/docker/modify_yum_source.sh
@@ -19,9 +19,16 @@ case $RELEASE_VER in
     yum makecache timer
     ;;
   .el7)
-    sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-        -e "s|^#baseurl=http://mirror.centos.org/centos|baseurl=${MIRROR_URL}/centos|g" \
-        -i.bak /etc/yum.repos.d/CentOS-*.repo && \
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/altarch/|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-altarch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/$contentdir/|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-altarch/|g' \
+            -i.bak /etc/yum.repos.d/CentOS-*.repo;
+    elif [ "$(uname -m)" = "x86_64" ]; then
+        sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e "s|^#baseurl=http://mirror.centos.org/centos|baseurl=${MIRROR_URL}/centos|g" \
+            -i.bak /etc/yum.repos.d/CentOS-*.repo;
+    fi && \
     rm -rf /var/cache/yum/ && \
     yum makecache fast
     ;;

--- a/el5/SPECS/openssh.spec
+++ b/el5/SPECS/openssh.spec
@@ -329,6 +329,13 @@ UseDNS no
 UsePAM yes
 KexAlgorithms -diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
 EOF
+# Modify ssh config file, to ensure that traditional RSA-type key authentication is available to avoid git clone failures.
+# See: https://support.genymotion.com/hc/en-us/articles/9500420360093-I-get-the-error-no-matching-host-key-type-found-Their-offer-ssh-rsa-when-trying-to-connect-with-SSH
+cat << EOF >> $RPM_BUILD_ROOT/etc/ssh/ssh_config
+Host *
+    HostKeyAlgorithms = +ssh-rsa
+    PubkeyAcceptedAlgorithms = +ssh-rsa
+EOF
 
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install -m644 contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/

--- a/el6/SPECS/openssh.spec
+++ b/el6/SPECS/openssh.spec
@@ -316,6 +316,13 @@ UseDNS no
 UsePAM yes
 KexAlgorithms -diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
 EOF
+# Modify ssh config file, to ensure that traditional RSA-type key authentication is available to avoid git clone failures.
+# See: https://support.genymotion.com/hc/en-us/articles/9500420360093-I-get-the-error-no-matching-host-key-type-found-Their-offer-ssh-rsa-when-trying-to-connect-with-SSH
+cat << EOF >> $RPM_BUILD_ROOT/etc/ssh/ssh_config
+Host *
+    HostKeyAlgorithms = +ssh-rsa
+    PubkeyAcceptedAlgorithms = +ssh-rsa
+EOF
 
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install -m644 contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/

--- a/el7/SPECS/openssh.spec
+++ b/el7/SPECS/openssh.spec
@@ -314,6 +314,13 @@ UseDNS no
 UsePAM yes
 KexAlgorithms -diffie-hellman-group1-sha1,diffie-hellman-group1-sha256,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group15-sha256,diffie-hellman-group15-sha512,diffie-hellman-group16-sha256,diffie-hellman-group16-sha512,diffie-hellman-group17-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha512
 EOF
+# Modify ssh config file, to ensure that traditional RSA-type key authentication is available to avoid git clone failures.
+# See: https://support.genymotion.com/hc/en-us/articles/9500420360093-I-get-the-error-no-matching-host-key-type-found-Their-offer-ssh-rsa-when-trying-to-connect-with-SSH
+cat << EOF >> $RPM_BUILD_ROOT/etc/ssh/ssh_config
+Host *
+    HostKeyAlgorithms = +ssh-rsa
+    PubkeyAcceptedAlgorithms = +ssh-rsa
+EOF
 
 install -m755 contrib/ssh-copy-id $RPM_BUILD_ROOT%{_bindir}/
 install -m644 contrib/ssh-copy-id.1 $RPM_BUILD_ROOT%{_mandir}/man1/


### PR DESCRIPTION
- Modify `openssh.spec` to fix traditional ssh RSA alg support, ensure git works well.
- Modify `modify_yum_source.sh`, add support for support CentOS 7 with arm arch.
- Modify `Dockerfile.centos-stream`, fix CentOS 8 yum china mirror error.
- Modify `docker.README.md`, add TL;DR part and some usefule tip for arm users.