### PR TITLE
Fix CentOS 7 mirror deprecated error

### DIFF
--- a/docker.README.md
+++ b/docker.README.md
@@ -168,23 +168,23 @@ echo 'The building has been completed!'
 ##### Push images
 
 ```shell
-  # Specify build versions
-  VERSIONS=("8" "7" "6" "5")
+# Specify build versions
+VERSIONS=("8" "7" "6" "5")
 
-  for VERSION in "${VERSIONS[@]}"
-  do
-    echo "Pushing version: ${VERSION}"
-    # Tag image
-    docker tag $COMPONENT:centos$VERSION $COMPONENT:centos.$VERSION
-    docker tag $COMPONENT:centos$VERSION $COMPONENT:centos.$VERSION.$(date +%Y%m%d)
-    docker tag $COMPONENT:centos$VERSION $COMPONENT:el$VERSION
-    # Push image
-    docker push $COMPONENT:centos$VERSION
-    docker push $COMPONENT:centos.$VERSION
-    docker push $COMPONENT:centos.$VERSION.$(date +%Y%m%d)
-    docker push $COMPONENT:el$VERSION
-  done
-  echo 'Push has been completed!'
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Pushing version: ${VERSION}"
+  # Tag image
+  docker tag $COMPONENT:centos$VERSION $COMPONENT:centos.$VERSION
+  docker tag $COMPONENT:centos$VERSION $COMPONENT:centos.$VERSION.$(date +%Y%m%d)
+  docker tag $COMPONENT:centos$VERSION $COMPONENT:el$VERSION
+  # Push image
+  docker push $COMPONENT:centos$VERSION
+  docker push $COMPONENT:centos.$VERSION
+  docker push $COMPONENT:centos.$VERSION.$(date +%Y%m%d)
+  docker push $COMPONENT:el$VERSION
+done
+echo 'Push has been completed!'
 ```
 
 #### CentOS Stream
@@ -214,23 +214,23 @@ echo 'The building has been completed!'
 ##### Push images
 
 ```shell
-  # Specify build versions
-  VERSIONS=("9" "8")
+# Specify build versions
+VERSIONS=("9" "8")
 
-  for VERSION in "${VERSIONS[@]}"
-  do
-    echo "Pushing version: ${VERSION}"
-    # Tag image
-    docker tag $COMPONENT:centos-stream$VERSION $COMPONENT:centos-stream.$VERSION
-    docker tag $COMPONENT:centos-stream$VERSION $COMPONENT:centos-stream.$VERSION.$(date +%Y%m%d)
-    docker tag $COMPONENT:centos-stream$VERSION $COMPONENT:el$VERSION
-    # Push image
-    docker push $COMPONENT:centos-stream$VERSION
-    docker push $COMPONENT:centos-stream.$VERSION
-    docker push $COMPONENT:centos-stream.$VERSION.$(date +%Y%m%d)
-    docker push $COMPONENT:el$VERSION
-  done
-  echo 'Push has been completed!'
+for VERSION in "${VERSIONS[@]}"
+do
+  echo "Pushing version: ${VERSION}"
+  # Tag image
+  docker tag $COMPONENT:centos-stream$VERSION $COMPONENT:centos-stream.$VERSION
+  docker tag $COMPONENT:centos-stream$VERSION $COMPONENT:centos-stream.$VERSION.$(date +%Y%m%d)
+  docker tag $COMPONENT:centos-stream$VERSION $COMPONENT:el$VERSION
+  # Push image
+  docker push $COMPONENT:centos-stream$VERSION
+  docker push $COMPONENT:centos-stream.$VERSION
+  docker push $COMPONENT:centos-stream.$VERSION.$(date +%Y%m%d)
+  docker push $COMPONENT:el$VERSION
+done
+echo 'Push has been completed!'
 ```
 
 #### Amazon Linux
@@ -328,6 +328,11 @@ This script below can compile rpm packages for all support systems.
 
 ```bash
 # Download all src files
+source version.env
+PERLMIR=https://www.cpan.org/src/5.0
+if [[ ! -f downloads/$PERLSRC ]]; then
+	curl -k -o downloads/$PERLSRC $PERLMIR/$PERLSRC
+fi
 bash ./pullsrc.sh
 # Define whether to enable Tsinghua University mirror source. (Very useful for Chinese users)
 CHINA_MIRROR=1  # Setting this variable to non-zero means enabling

--- a/docker/modify_yum_source.sh
+++ b/docker/modify_yum_source.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Author: Rex Chow
-# Modified: 2024/2/5 08:49
+# Modified: 2024-07-03 11:28:16
 # Description: This script will modify yum repositories to Tsinghua University mirror.
 # Copyright: Copyright © 2024 Rex Zhou. All rights reserved.
 
@@ -26,7 +26,8 @@ case $RELEASE_VER in
             -i.bak /etc/yum.repos.d/CentOS-*.repo;
     elif [ "$(uname -m)" = "x86_64" ]; then
         sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e "s|^#baseurl=http://mirror.centos.org/centos|baseurl=${MIRROR_URL}/centos|g" \
+        -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=${MIRROR_URL}/centos-vault/7.9.2009|g" \
+        -e "s|^#baseurl=http://mirror.centos.org/\$contentdir/\$releasever|baseurl=${MIRROR_URL}/centos-vault/7.9.2009|g" \
             -i.bak /etc/yum.repos.d/CentOS-*.repo;
     fi && \
     rm -rf /var/cache/yum/ && \

--- a/docker/modify_yum_source.sh
+++ b/docker/modify_yum_source.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Author: Rex Chow
-# Modified: 2024-07-03 11:28:16
+# Modified: 2024-07-04 11:18:49
 # Description: This script will modify yum repositories to Tsinghua University mirror.
 # Copyright: Copyright © 2024 Rex Zhou. All rights reserved.
 
@@ -21,8 +21,8 @@ case $RELEASE_VER in
   .el7)
     if [ "$(uname -m)" = "aarch64" ]; then
         sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/altarch/|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-altarch/|g' \
-            -e 's|^#baseurl=http://mirror.centos.org/$contentdir/|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-altarch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/altarch/|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-vault/altarch/|g' \
+            -e 's|^#baseurl=http://mirror.centos.org/$contentdir/|baseurl=https://mirrors.tuna.tsinghua.edu.cn/centos-vault/altarch/|g' \
             -i.bak /etc/yum.repos.d/CentOS-*.repo;
     elif [ "$(uname -m)" = "x86_64" ]; then
         sed -e 's|^mirrorlist=|#mirrorlist=|g' \


### PR DESCRIPTION
- CentOS 7 yum repo was deprecated at 2024-06-30, so using `vault` as a replacement.
- Fix `docker.README.md` style error.